### PR TITLE
Add source text pronunciation.

### DIFF
--- a/src/main/kotlin/me/bush/translator/Translation.kt
+++ b/src/main/kotlin/me/bush/translator/Translation.kt
@@ -47,6 +47,19 @@ class Translation internal constructor(
     val pronunciation = jsonData[0].jsonArray.last().jsonArray[2].string
 
     /**
+     * The pronunciation of the source text. This is generally
+     * null when the source language uses the Roman/Latin Alphabet.
+     */
+    val pronunciationSource = run {
+        val jsonArray = jsonData[0].jsonArray.last().jsonArray
+        if (jsonArray.size > 3) {
+            jsonArray[3].string
+        } else {
+            null
+        }
+    }
+
+    /**
      * The language of the translated text. This is useful
      * if the source language was set to [Language.AUTO].
      */

--- a/src/test/kotlin/TranslatorTest.kt
+++ b/src/test/kotlin/TranslatorTest.kt
@@ -22,7 +22,7 @@ class TranslatorTest {
                 Goin' a lil KOOKY… He's off the walls! Bananas! Loco! You want me to stop. Isn't that wonderful. Well 
                 lemme just do whatever you say, because it's your little fairy tale.
             """.trimIndent(),
-            target = Language.values().filter { it != Language.ENGLISH }.random(),
+            target = Language.entries.filter { it != Language.ENGLISH && it != Language.AUTO }.random(),
             source = Language.AUTO
         )
         println(translation.url)
@@ -31,5 +31,6 @@ class TranslatorTest {
         println(translation.targetLanguage)
         println(translation.sourceLanguage)
         println(translation.pronunciation)
+        println(translation.pronunciationSource)
     }
 }


### PR DESCRIPTION
- added pronunciation for source text
  - did not rename the other variable, but it would make sense (like `pronunciationTarget`)
- improved test code
  - also fixes a crash when `target` is set to `Language.AUTO`